### PR TITLE
Mac compatibility

### DIFF
--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -52,9 +52,15 @@ function addKeyboardShortcuts() {
         // First check if user has an open tweet reply window. If so, ignore any "Delete" keypress
         var userIsReplying = $('.js-inline-reply').length > 0;
 
+        // Next check if user is viewing the expanded detail of a selected tweet, in which case Delete key should just return to column view and not clear the column.
+        var userIsReturningFromDetail = $('.js-tweet-detail').length > 0;
+
         key[e.keyCode] = e.type == 'keydown';
 
-        if (!userIsReplying && (test_key('del') || test_key('mac-del'))) {
+        if (
+        	(!userIsReplying && !userIsReturningFromDetail) && 
+        	(test_key('del') || test_key('mac-del'))
+        ) {
         
             $jsColumnFocused = $('.js-column.is-focused');
             if ($jsColumnFocused.length) {

--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -73,12 +73,12 @@ function addKeyboardShortcuts() {
                 $isSelectedTweet.parents('.js-column').find('.js-user-button').trigger('click');
                 key = [];
             }
-        }
+        } else key = [];
 
         if (!userIsReplying && (test_keys('alt', 'del') || test_keys('mac-cmd', 'mac-del'))) {
             $('.js-user-buttonAll').trigger('click');
             key = [];
-        }
+        } else key = [];
     });
 }
 

--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -49,8 +49,8 @@ var key = [];
 function addKeyboardShortcuts() {
     $(document).on("keydown keyup", function(e){
 
-        // First check if user has an open tweet reply window. If so, ignore any "Delete" keypress
-        var userIsReplying = $('.js-inline-reply').length > 0;
+        // First check if user has an open tweet compose or reply window. If so, ignore any "Delete" keypress
+        var userIsReplying = $('.js-inline-reply').length > 0 || $('.js-compose-text').is(':focus');
 
         // Next check if user is viewing the expanded detail of a selected tweet, in which case Delete key should just return to column view and not clear the column.
         var userIsReturningFromDetail = $('.js-tweet-detail').length > 0;

--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -90,7 +90,7 @@ function test_key(selkey){
         "shift": 16,
         "C":     67,
         "del":   46,
-        "mac-del"; 8
+        "mac-del": 8
     };
     return key[selkey] || key[alias[selkey]];
 }

--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -50,7 +50,7 @@ function addKeyboardShortcuts() {
     $(document).on("keydown keyup", function(e){
         key[e.keyCode] = e.type == 'keydown';
 
-        if (test_key('del')) {
+        if (test_key('del') || test_key('mac-del')) {
             $jsColumnFocused = $('.js-column.is-focused');
             if ($jsColumnFocused.length) {
                 $jsColumnFocused.find('.js-user-button').trigger('click');
@@ -79,6 +79,7 @@ function test_key(selkey){
         "shift": 16,
         "C":     67,
         "del":   46,
+        "mac-del"; 8
     };
     return key[selkey] || key[alias[selkey]];
 }

--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name    TweetDeck Clear
 // @namespace   http://b1nj.fr
-// @version 0.6.2
+// @version 0.6.3
 // @icon https://ton.twimg.com/tweetdeck-web/web/assets/logos/favicon.3d5d8f1cbe.ico
 // @description Add buttons and keyboard shortcuts to tweetdeck for clear all tweets or column tweets
 // @match   https://tweetdeck.twitter.com/*

--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -73,12 +73,15 @@ function addKeyboardShortcuts() {
                 $isSelectedTweet.parents('.js-column').find('.js-user-button').trigger('click');
                 key = [];
             }
-        } else key = [];
+        }
 
         if (!userIsReplying && (test_keys('alt', 'del') || test_keys('mac-cmd', 'mac-del'))) {
             $('.js-user-buttonAll').trigger('click');
             key = [];
-        } else key = [];
+        }
+        
+        // If we are skipping because user is replying or returning from detail, still clear out the key array so those keypresses don't get counted with future keypresses
+        if (userIsReplying || userIsReturningFromDetail) key = [];
     });
 }
 

--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -75,7 +75,7 @@ function addKeyboardShortcuts() {
             }
         }
 
-        if (!userIsReplying && (test_keys('alt', 'del') || test_keys('mac-cmd', 'mac-del'))) {
+        if (!userIsReplying && (test_keys('alt', 'del') || test_keys('ctrl', 'mac-del'))) {
             $('.js-user-buttonAll').trigger('click');
             key = [];
         }

--- a/TweetDeck_Clear.user.js
+++ b/TweetDeck_Clear.user.js
@@ -48,9 +48,14 @@ function clearTweets($col) {
 var key = [];
 function addKeyboardShortcuts() {
     $(document).on("keydown keyup", function(e){
+
+        // First check if user has an open tweet reply window. If so, ignore any "Delete" keypress
+        var userIsReplying = $('.js-inline-reply').length > 0;
+
         key[e.keyCode] = e.type == 'keydown';
 
-        if (test_key('del') || test_key('mac-del')) {
+        if (!userIsReplying && (test_key('del') || test_key('mac-del'))) {
+        
             $jsColumnFocused = $('.js-column.is-focused');
             if ($jsColumnFocused.length) {
                 $jsColumnFocused.find('.js-user-button').trigger('click');
@@ -64,7 +69,7 @@ function addKeyboardShortcuts() {
             }
         }
 
-        if (test_keys('alt', 'del')) {
+        if (!userIsReplying && (test_keys('alt', 'del') || test_keys('mac-cmd', 'mac-del'))) {
             $('.js-user-buttonAll').trigger('click');
             key = [];
         }


### PR DESCRIPTION
Edits to fix some bugs and to make the script compatible with Mac computers, which need to listen for different keycode for "Delete" keypress:

1. Add to alias list to detect Mac delete keypress
2. Add checks to prevent clear action if user is trying to use the Delete key to actually delete text in a reply (fixes submitted Issue #2) or to back up from an expanded tweet detail.

Thanks!